### PR TITLE
[chore] chezmoi initのデフォルト構成に対応

### DIFF
--- a/.chezmoiroot
+++ b/.chezmoiroot
@@ -1,0 +1,1 @@
+chezmoi

--- a/.github/workflows/chezmoi-check.yml
+++ b/.github/workflows/chezmoi-check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Render personal profile config
         run: |
           chezmoi execute-template \
-            --source "$GITHUB_WORKSPACE/chezmoi" \
+            --source "$GITHUB_WORKSPACE" \
             --init \
             --override-data '{"is_personal_pc":true}' \
             --file "$GITHUB_WORKSPACE/chezmoi/.chezmoi.toml.tmpl" \
@@ -33,7 +33,7 @@ jobs:
       - name: Validate gitconfig template render
         run: |
           chezmoi execute-template \
-            --source "$GITHUB_WORKSPACE/chezmoi" \
+            --source "$GITHUB_WORKSPACE" \
             --config "$RUNNER_TEMP/chezmoi.toml" \
             --config-format toml \
             < "$GITHUB_WORKSPACE/chezmoi/dot_gitconfig.tmpl" \
@@ -43,7 +43,7 @@ jobs:
         run: |
           mkdir -p "$RUNNER_TEMP/home"
           chezmoi apply \
-            --source "$GITHUB_WORKSPACE/chezmoi" \
+            --source "$GITHUB_WORKSPACE" \
             --config "$RUNNER_TEMP/chezmoi.toml" \
             --config-format toml \
             --destination "$RUNNER_TEMP/home" \

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This repository is managed with `chezmoi`.
 1. Install and apply chezmoi with the official bootstrap
 
 ```sh
-sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply shsw228 --source="$HOME/Developer/ghq/github.com/shsw228/dotfiles/chezmoi"
+sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply shsw228
 ```
 
 2. If chezmoi is already installed, you can apply the same source directly
 
 ```sh
-chezmoi init --apply --source="$HOME/Developer/ghq/github.com/shsw228/dotfiles/chezmoi"
+chezmoi init --apply shsw228
 ```
 
 At `chezmoi init`, you will be asked whether this is a personal PC. If you answer `yes`, Git user settings are filled with personal defaults. If you answer `no`, you can choose interactive input for work `user.name` / `user.email`; declining this exits with an error.


### PR DESCRIPTION
## 概要
- ルートに `.chezmoiroot` を追加し、source state を `chezmoi/` に固定
- `chezmoi init --apply shsw228` を前提に README を更新
- CI を repo root を source にした構成へ更新
- 会社PC向けに `CHEZMOI_IS_PERSONAL_PC` / `GIT_NAME` / `GIT_EMAIL` を使った初期化入力の安定化を追加

## 変更理由
- `chezmoi init shsw228` のデフォルト clone 先でも、そのまま初期化と設定投入が動くようにするため
- 対話入力が不安定な環境でも、会社用 Git 設定を確実に与えられるようにするため

## 補足
- 個人PCでは従来どおり個人用の既定値を利用
- 会社PCでは `GIT_NAME` / `GIT_EMAIL` があればそれを優先し、なければ対話入力を試みる
- 対話が使えない環境向けに README では環境変数指定の実行例を案内

## 確認
- `chezmoi managed --source "$PWD"`
- `chezmoi apply --source "$PWD" --dry-run --no-tty`
- `chezmoi execute-template --init --file chezmoi/.chezmoi.toml.tmpl`
