### PR TITLE
[fix] chezmoi初期化入力の安定性を改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply shsw228
 chezmoi init --apply shsw228
 ```
 
-At `chezmoi init`, you will be asked whether this is a personal PC. If you answer `yes`, Git user settings are filled with personal defaults. If you answer `no`, `user.name` / `user.email` are taken from `GIT_NAME` / `GIT_EMAIL` when set, otherwise they are requested interactively.
+At `chezmoi init`, you will be asked whether this is a personal PC. If you answer `yes`, Git user settings are filled with personal defaults. If you answer `no`, `user.name` / `user.email` are requested interactively unless `GIT_NAME` / `GIT_EMAIL` are already set. In some environments, `chezmoi init` may not get a usable TTY for prompts, so explicit environment variables are the most reliable option for work machines.
 
 For work machines, this non-interactive form is the most reliable:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply shsw228
 chezmoi init --apply shsw228
 ```
 
-At `chezmoi init`, you will be asked whether this is a personal PC. If you answer `yes`, Git user settings are filled with personal defaults. If you answer `no`, you can choose interactive input for work `user.name` / `user.email`; declining this exits with an error.
+At `chezmoi init`, you will be asked whether this is a personal PC. If you answer `yes`, Git user settings are filled with personal defaults. If you answer `no`, `user.name` / `user.email` are taken from `GIT_NAME` / `GIT_EMAIL` when set, otherwise they are requested interactively.
+
+For work machines, this non-interactive form is the most reliable:
+
+```sh
+CHEZMOI_IS_PERSONAL_PC=false \
+GIT_NAME="Your Name" \
+GIT_EMAIL="you@company.com" \
+chezmoi init --apply shsw228
+```
 
 3. Confirm the installed `chezmoi` is looking at the expected source
 

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -1,4 +1,16 @@
-{{- $isPersonalPC := promptBoolOnce . "is_personal_pc" "このPCは個人用ですか？" true -}}
+{{- $isPersonalPC := false -}}
+{{- if hasKey . "is_personal_pc" -}}
+{{- $isPersonalPC = .is_personal_pc -}}
+{{- else -}}
+{{- $isPersonalEnv := lower (env "CHEZMOI_IS_PERSONAL_PC") -}}
+{{- if or (eq $isPersonalEnv "1") (eq $isPersonalEnv "true") (eq $isPersonalEnv "yes") (eq $isPersonalEnv "y") -}}
+{{- $isPersonalPC = true -}}
+{{- else if or (eq $isPersonalEnv "0") (eq $isPersonalEnv "false") (eq $isPersonalEnv "no") (eq $isPersonalEnv "n") -}}
+{{- $isPersonalPC = false -}}
+{{- else -}}
+{{- $isPersonalPC = promptBoolOnce . "is_personal_pc" "このPCは個人用ですか？" true -}}
+{{- end -}}
+{{- end -}}
 [data.profile]
 is_personal_pc = {{ $isPersonalPC }}
 
@@ -6,12 +18,13 @@ is_personal_pc = {{ $isPersonalPC }}
 [data.git]
 name = "hume"
 email = "13506491+shsw228@users.noreply.github.com"
-{{- else }}
-{{- $configureWorkGit := promptBoolOnce . "configure_work_git" "会社用のgit user.name / user.emailを対話的に設定しますか？（Noならエラー終了）" false -}}
-{{- if not $configureWorkGit -}}
-{{- fail "個人用PCではないため、git user.name/user.email の設定が必要です。対話設定を有効にして再実行してください。" -}}
-{{- end }}
+{{ else }}
+{{- $gitName := or (env "GIT_NAME") (promptStringOnce . "git_name" "会社用のgit user.nameを入力してください" "") -}}
+{{- $gitEmail := or (env "GIT_EMAIL") (promptStringOnce . "git_email" "会社用のgit user.emailを入力してください" "") -}}
+{{- if or (eq $gitName "") (eq $gitEmail "") -}}
+{{- fail "会社用PCでは GIT_NAME/GIT_EMAIL を指定するか、対話で git user.name/user.email を入力してください。" -}}
+{{ end }}
 [data.git]
-name = {{ promptStringOnce . "git_name" "会社用のgit user.nameを入力してください" "" | quote }}
-email = {{ promptStringOnce . "git_email" "会社用のgit user.emailを入力してください" "" | quote }}
+name = {{ $gitName | quote }}
+email = {{ $gitEmail | quote }}
 {{- end }}


### PR DESCRIPTION
## 概要
- ルートに `.chezmoiroot` を追加し、source state を `chezmoi/` に固定
- `chezmoi init --apply shsw228` を前提に README を更新
- CI を repo root を source にした構成へ更新
- 会社PC向けに `CHEZMOI_IS_PERSONAL_PC` / `GIT_NAME` / `GIT_EMAIL` を使った初期化入力の安定化を追加
- README に、対話入力と環境変数指定の使い分けを明記

## 変更理由
- `chezmoi init shsw228` のデフォルト clone 先でも、そのまま初期化と設定投入が動くようにするため
- 対話入力が不安定な環境でも、会社用 Git 設定を確実に与えられるようにするため

## 補足
- 個人PCでは従来どおり個人用の既定値を利用
- 会社PCでは `GIT_NAME` / `GIT_EMAIL` があればそれを優先し、なければ対話入力を試みる
- 会社PCでは環境変数指定の実行例を README に記載

## 確認
- `chezmoi managed --source "$PWD"`
- `chezmoi apply --source "$PWD" --dry-run --no-tty`
- `chezmoi execute-template --init --file chezmoi/.chezmoi.toml.tmpl`
