### PR TITLE
[fix] zoxide DB が空のとき ^g で fzf が一瞬表示されないようにする

### DIFF
--- a/chezmoi/dot_config/zsh/dot_zshrc
+++ b/chezmoi/dot_config/zsh/dot_zshrc
@@ -111,6 +111,10 @@ if command -v zoxide >/dev/null 2>&1; then
   case $- in
     *i*)
       function _zoxide_zi() {
+        if [ -z "$(zoxide query -l 2>/dev/null)" ]; then
+          zle reset-prompt
+          return
+        fi
         local result
         result=$(zoxide query -i </dev/tty)
         if [ -n "${result}" ]; then


### PR DESCRIPTION
## Summary
- 新規端末などで zoxide の履歴がまだ空の場合、`_zoxide_zi` 内で `zoxide query -i` が呼ばれ、fzf が入力ゼロのまま即終了して画面がフラッシュする挙動になっていた
- 事前に `zoxide query -l` で履歴の有無を判定し、空なら fzf を起動せずプロンプト復帰だけで終了するようにした

## Test plan
- [ ] 履歴が空の端末で `^g` を押下 → フラッシュせず即座に元のプロンプトに戻る
- [ ] 履歴がある端末で `^g` → 従来通り fzf で対話選択できる