### PR TITLE
[chore] 初回HTTPS cloneとSSH自動仕上げ(スピナー待機)への整理

### DIFF
--- a/.github/workflows/chezmoi-check.yml
+++ b/.github/workflows/chezmoi-check.yml
@@ -108,6 +108,7 @@ jobs:
           sh -n "$GITHUB_WORKSPACE/chezmoi/run_onchange_20_apply-macos-defaults.sh.tmpl"
           sh -n "$GITHUB_WORKSPACE/chezmoi/run_onchange_30_configure-login-items.sh.tmpl"
           sh -n "$GITHUB_WORKSPACE/chezmoi/run_onchange_50_set-ssh-auth-sock.sh.tmpl"
+          sh -n "$GITHUB_WORKSPACE/chezmoi/run_60_finalize-ssh-remote.sh.tmpl"
           zsh -n "$GITHUB_WORKSPACE/chezmoi/dot_zprofile"
           zsh -n "$GITHUB_WORKSPACE/chezmoi/dot_zshenv"
           zsh -n "$GITHUB_WORKSPACE/chezmoi/dot_zshrc"

--- a/README.md
+++ b/README.md
@@ -6,33 +6,14 @@ macOS dotfiles managed with [chezmoi](https://www.chezmoi.io/).
 
 ## Fresh Machine Setup
 
-### 1. Prepare 1Password and SSH
+### 1. Bootstrap with chezmoi (HTTPS)
 
-1. Install [1Password](https://1password.com/), sign in, and unlock it
-2. Settings → Developer → enable **Use the SSH agent**
-3. Write a minimal `~/.ssh/config` so the SSH clone in step 2 can reach GitHub through the 1Password agent. No `op` CLI is needed — the agent offers the keys.
-
-```sh
-mkdir -p ~/.ssh && chmod 700 ~/.ssh
-cat > ~/.ssh/config <<'EOF'
-Host github.com
-    User git
-    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
-EOF
-chmod 600 ~/.ssh/config
-```
-
-`chezmoi apply` (step 2) overwrites `~/.ssh/config` with the persona-specific config (personal key on personal PCs, work key on work PCs).
-
-### 2. Bootstrap with chezmoi
-
-`--source` を指定して、リポジトリを最初から ghq レイアウトのパスに直接クローンする
-（`~/.local/share/chezmoi` への二重クローンは発生しない）。
+The repo is public, so the initial clone needs no SSH key or 1Password. Clone over HTTPS; `chezmoi apply` then installs Homebrew, the Brewfile (including 1Password), and all config.
 
 ```sh
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply \
   --source="$HOME/Developer/ghq/github.com/shsw228/dotfiles" \
-  git@github.com:shsw228/dotfiles.git
+  https://github.com/shsw228/dotfiles.git
 ```
 
 During `chezmoi init`, you will be asked whether this is a personal PC.
@@ -48,10 +29,28 @@ GIT_NAME="Your Name" \
 GIT_EMAIL="you@company.com" \
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply \
   --source="$HOME/Developer/ghq/github.com/shsw228/dotfiles" \
-  git@github.com:shsw228/dotfiles.git
+  https://github.com/shsw228/dotfiles.git
 ```
 
-### 3. Verify
+### 2. Enable the 1Password SSH agent
+
+1Password is installed by the Brewfile in step 1 (no `op` CLI needed — the desktop app provides the agent). Then:
+
+1. Open 1Password, sign in, and unlock it
+2. Settings → Developer → enable **Use the SSH agent**
+
+`~/.ssh/config` (already placed by chezmoi) points `IdentityAgent` at the app's socket, so the SSH keys in your vault become usable with no key files on disk.
+
+### 3. Switch the dotfiles remote to SSH
+
+The initial clone used HTTPS. Once the agent is up, switch the remote to SSH so future pull/push go through the 1Password agent:
+
+```sh
+git -C "$HOME/Developer/ghq/github.com/shsw228/dotfiles" \
+  remote set-url origin git@github.com:shsw228/dotfiles.git
+```
+
+### 4. Verify
 
 ```sh
 chezmoi source-path

--- a/README.md
+++ b/README.md
@@ -32,25 +32,18 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply \
   https://github.com/shsw228/dotfiles.git
 ```
 
-### 2. Enable the 1Password SSH agent
+### 2. Enable the 1Password SSH agent (when prompted)
 
-1Password is installed by the Brewfile in step 1 (no `op` CLI needed — the desktop app provides the agent). Then:
+Near the end of `chezmoi apply`, a finalize step pauses with a spinner and asks you to:
 
-1. Open 1Password, sign in, and unlock it
+1. Open 1Password (installed by the Brewfile — no `op` CLI needed), sign in, and unlock it
 2. Settings → Developer → enable **Use the SSH agent**
 
-`~/.ssh/config` (already placed by chezmoi) points `IdentityAgent` at the app's socket, so the SSH keys in your vault become usable with no key files on disk.
+As soon as the agent is reachable, the step automatically switches the dotfiles remote from HTTPS to SSH (`git@github.com:…`) so future pull/push go through the agent, then `chezmoi apply` finishes. `~/.ssh/config` (placed by chezmoi) already points `IdentityAgent` at the app socket, so keys stay in your vault — none on disk.
 
-### 3. Switch the dotfiles remote to SSH
+On non-interactive runs (CI, no TTY) this step is skipped, and it times out after ~5 minutes if left unattended.
 
-The initial clone used HTTPS. Once the agent is up, switch the remote to SSH so future pull/push go through the 1Password agent:
-
-```sh
-git -C "$HOME/Developer/ghq/github.com/shsw228/dotfiles" \
-  remote set-url origin git@github.com:shsw228/dotfiles.git
-```
-
-### 4. Verify
+### 3. Verify
 
 ```sh
 chezmoi source-path

--- a/chezmoi/Brewfile
+++ b/chezmoi/Brewfile
@@ -40,7 +40,6 @@ brew "xcodes", link: false
 brew "yammerjp/tap/pdef"
 
 cask "1password"
-cask "1password-cli"
 cask "lihaoyun6/tap/airbattery"
 cask "alt-tab"
 cask "arto"

--- a/chezmoi/run_60_finalize-ssh-remote.sh.tmpl
+++ b/chezmoi/run_60_finalize-ssh-remote.sh.tmpl
@@ -1,0 +1,42 @@
+#!/bin/sh
+# 初回 clone は HTTPS。1Password の SSH エージェントが使えるようになったら
+# dotfiles の origin を SSH へ張り替え、以降の pull/push を agent 経由にする。
+# 既に SSH origin なら即終了（べき等）。CI / 非TTY では待機しない。
+set -eu
+
+[ "${CHEZMOI_CI:-0}" = "1" ] && exit 0
+[ -t 1 ] || exit 0
+
+repo="$(dirname "{{ .chezmoi.sourceDir }}")"
+
+# 既に SSH origin なら何もしない
+case "$(git -C "$repo" remote get-url origin 2>/dev/null || true)" in
+  git@github.com:* | ssh://git@github.com/*) exit 0 ;;
+esac
+
+sock="$HOME/.1password-agent.sock"
+
+# エージェントがまだ使えなければ、有効化を促してスピナーで待つ
+if ! env SSH_AUTH_SOCK="$sock" ssh-add -l >/dev/null 2>&1; then
+  printf '\n1Password にサインインし、設定 → 開発者 → 「SSH エージェントを使用」を有効化してください\n'
+  frames="⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏"
+  i=0
+  max=3000 # 約5分 (0.1s * 3000) でタイムアウト
+  while :; do
+    if [ $((i % 10)) -eq 0 ] && env SSH_AUTH_SOCK="$sock" ssh-add -l >/dev/null 2>&1; then
+      break
+    fi
+    if [ "$i" -ge "$max" ]; then
+      printf '\r\033[33m⚠\033[0m タイムアウト: 後で `git -C %s remote set-url origin git@github.com:shsw228/dotfiles.git` を手動実行してください\n' "$repo"
+      exit 0
+    fi
+    f=$(set -- $frames; eval "printf %s \"\${$((i % 10 + 1))}\"")
+    printf '\r%s SSH エージェントを待機中…' "$f"
+    i=$((i + 1))
+    sleep 0.1
+  done
+  printf '\r\033[32m✔\033[0m SSH エージェントを検出しました        \n'
+fi
+
+git -C "$repo" remote set-url origin git@github.com:shsw228/dotfiles.git
+echo "dotfiles の origin を SSH に切り替えました"


### PR DESCRIPTION
## 概要
新規マシンのブートストラップを「初回 HTTPS clone → apply 内で 1Password SSH エージェント有効化を待って origin を SSH へ自動切替」に整理する。前回 PR #15 のフォロー。

## 背景
- 完全初期のマシンには SSH 鍵が無いため、SSH clone を前提にすると初回取得が 1Password の完全セットアップに依存して脆い。
- リポジトリは public なので **HTTPS なら鍵も 1Password も無しで clone できる**。
- SSH エージェントは **1Password デスクトップアプリのみ**で足りる（`op` CLI 不要）。

## 変更点

### 初回 clone を HTTPS 化
- README のブートストラップを `git@…` → `https://…` に変更。鍵/1Password 無しで取得できる。

### 未使用の 1Password CLI を撤去
- `setup-ssh.sh` と NotchNook 撤去で `op` の利用箇所が消えたため、`cask "1password-cli"` を Brewfile から削除。

### apply 終盤に SSH 仕上げステップを追加（`run_60_finalize-ssh-remote.sh.tmpl`）
- 1Password サインイン＋SSH エージェント有効化を**スピナー付きで待機**（`cli-spinners` の dots 相当を pure sh で実装、依存ゼロ）。
- エージェント検出後、dotfiles の origin を `git@github.com:…` へ**自動で張り替え**。
- **CI / 非TTY はスキップ**（`exit 0`）、**約5分でタイムアウト**、**SSH origin 既設なら即終了**（べき等）。

## べき等性
`run_60` は毎 apply で `origin` を確認し、SSH 既設なら即 `exit 0`。CI/非TTY もスキップするため自動実行を止めない。

## 検証
- CI の `sh -n`（テンプレート `{{ }}` 込み）を通過
- chezmoi レンダリング後も `sh -n` OK、`repo` が repo ルートに解決
- SSH origin 判定ガードの動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
