### PR TITLE
[fix] SbarLua の導入を lua インストール後に実行する

### DIFF
--- a/chezmoi/run_once_15_install-sbarlua.sh.tmpl
+++ b/chezmoi/run_once_15_install-sbarlua.sh.tmpl
@@ -11,6 +11,22 @@ if [ -f "$target" ]; then
   exit 0
 fi
 
+# 初回 apply 中は PATH に Homebrew の bin が入っていないことがあるため、
+# brew（直前の run_onchange_10 で入れた lua を含む）を PATH に足しておく。
+if command -v brew >/dev/null 2>&1; then
+  brew_prefix="$(brew --prefix)"
+elif [ -x /opt/homebrew/bin/brew ]; then
+  brew_prefix="$(/opt/homebrew/bin/brew --prefix)"
+elif [ -x /usr/local/bin/brew ]; then
+  brew_prefix="$(/usr/local/bin/brew --prefix)"
+else
+  brew_prefix=""
+fi
+if [ -n "$brew_prefix" ]; then
+  PATH="$brew_prefix/bin:$PATH"
+  export PATH
+fi
+
 if ! command -v lua >/dev/null 2>&1; then
   echo "lua が見つからないため SbarLua の導入をスキップします" >&2
   exit 0


### PR DESCRIPTION
## 概要

初回 apply で SbarLua が永久に導入されないバグを修正する。

## 問題

`run_once_05_install-sbarlua` は `lua` と `make` を必要とするが、`lua` を入れる `run_onchange_10_install-homebrew-packages` より前（`05` < `10`）に実行される。

- 新規マシンでは 05 実行時点で `lua` 未検出 → スキップして正常終了
- `run_once_*` は内容が変わるまで再実行されないため、以降も走らず **SbarLua が永久に入らない**
- 結果、sketchybar が Lua 設定を読めず主バーが機能しない

導入コミット `4de7641` の時点からこの順序であり、番号付け（run_once＝早い段階のセットアップという直感）で `lua` への依存が見落とされていた。

## 変更

- `run_once_05` → `run_once_15` にリネームし、`run_onchange_10`（lua 導入）の後に実行されるようにする
- 初回 apply 中は PATH に Homebrew の bin が入っていないことがあるため、`run_onchange_10` と同様に brew の prefix/bin を PATH に足してから `lua` を探すよう堅牢化（`make` は `/usr/bin/make` なので影響なし）

## 確認

- `sh -n` 構文チェック OK
- 旧ファイル名（README/CI）への参照なし
- 実行順序を全 run スクリプトで点検し、他に依存の破綻がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)