### PR TITLE
[feat] brew cask アプリの Gatekeeper 検疫属性を bundle 後に一括除去する

### DIFF
--- a/chezmoi/run_onchange_12_dequarantine-casks.sh.tmpl
+++ b/chezmoi/run_onchange_12_dequarantine-casks.sh.tmpl
@@ -1,0 +1,45 @@
+#!/bin/sh
+# brew cask で入れたアプリの Gatekeeper 検疫属性(com.apple.quarantine)を剥がす。
+# Homebrew 6.x で --no-quarantine が廃止されたため、bundle 後に一括で除去する。
+# 自分で管理する Brewfile 由来の cask は信頼する前提。
+#
+# Brewfile を変更(cask 追加など)したときだけ再実行されるよう、
+# Brewfile のハッシュを埋め込んでおく。
+# Brewfile hash: {{ include "Brewfile" | sha256sum }}
+set -eu
+
+if [ "${CHEZMOI_CI:-0}" = "1" ]; then
+  exit 0
+fi
+
+if command -v brew >/dev/null 2>&1; then
+  brew_cmd="$(command -v brew)"
+elif [ -x /opt/homebrew/bin/brew ]; then
+  brew_cmd="/opt/homebrew/bin/brew"
+elif [ -x /usr/local/bin/brew ]; then
+  brew_cmd="/usr/local/bin/brew"
+else
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq が見つからないため cask の de-quarantine をスキップします" >&2
+  exit 0
+fi
+
+casks="$("$brew_cmd" list --cask 2>/dev/null || true)"
+[ -z "$casks" ] && exit 0
+
+# 各 cask の .app 成果物を列挙し、配置先で検疫属性を除去する。
+# 配置先は既定の /Applications と、ユーザー領域の ~/Applications を対象にする。
+# shellcheck disable=SC2086
+"$brew_cmd" info --cask --json=v2 $casks 2>/dev/null \
+  | jq -r '.casks[].artifacts[]? | objects | .app[]?' \
+  | while IFS= read -r app; do
+      [ -z "$app" ] && continue
+      for dir in "/Applications" "$HOME/Applications"; do
+        target="$dir/$app"
+        [ -e "$target" ] || continue
+        xattr -dr com.apple.quarantine "$target" 2>/dev/null || true
+      done
+    done


### PR DESCRIPTION
## 概要

brew cask で入れたアプリの初回起動時に出る Gatekeeper の「開いてもよろしいですか」ダイアログを、apply の段階で出ないようにする。

## 背景

- Homebrew 6.x で `--no-quarantine` オプションは廃止済み（`brew install --help` に記載なし、渡すと弾かれる）
- そのため cask アプリには常に `com.apple.quarantine` が付き、全 cask アプリの初回起動でダイアログが出る

## 変更

`run_onchange_12_dequarantine-casks.sh.tmpl` を追加。`run_onchange_10`（brew bundle）の後に実行され、インストール済み cask の `.app` から検疫属性を一括除去する。

- `brew list --cask` + `brew info --cask --json=v2 | jq` で `.app` 成果物を列挙
- `/Applications` と `~/Applications` を対象に `xattr -dr com.apple.quarantine`（冪等）
- `.app` を持たない cask（フォント / pkg / ドライバ等）は自然に対象外
- スクリプトに Brewfile のハッシュを埋め込み、cask 追加時に再実行される
- CI（`CHEZMOI_CI=1`）ではスキップ

自分で管理する Brewfile 由来の cask は信頼する前提。

## 確認

- raw / 展開後とも `sh -n` OK、`chezmoi execute-template` で展開 OK
- jq フィルタが実機の 39 cask から 30 個の `.app` を正しく列挙
- 実機で検疫付き 21 アプリ → 実行後 0 を確認（BetterDisplay のダイアログも解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)