### PR TITLE
[fix] de-quarantine は検疫属性が付いているアプリのみ対象にする

### DIFF
--- a/chezmoi/run_onchange_12_dequarantine-casks.sh.tmpl
+++ b/chezmoi/run_onchange_12_dequarantine-casks.sh.tmpl
@@ -40,6 +40,10 @@ casks="$("$brew_cmd" list --cask 2>/dev/null || true)"
       for dir in "/Applications" "$HOME/Applications"; do
         target="$dir/$app"
         [ -e "$target" ] || continue
-        xattr -dr com.apple.quarantine "$target" 2>/dev/null || true
+        # 検疫属性が付いている場合のみ除去する。一度起動・承認済みのアプリは
+        # com.apple.macl / com.apple.provenance が付き macOS の App Management
+        # 保護対象になるため、触ると Permission denied になる（かつ除去は不要）。
+        xattr "$target" 2>/dev/null | grep -qx 'com.apple.quarantine' || continue
+        xattr -d com.apple.quarantine "$target" 2>/dev/null || true
       done
     done


### PR DESCRIPTION
## 概要

`run_onchange_12_dequarantine-casks` が、一度起動・承認済みのアプリに対しても検疫除去を試み、`xattr: [Errno 13] Permission denied` を出していた問題を修正する。

## 背景

一度起動・承認済みのアプリは `com.apple.macl` / `com.apple.provenance` が付き、macOS の App Management 保護対象になる。このため所有者であっても `xattr` での属性変更が Permission denied になる（かつ検疫は既に無く除去も不要）。

## 変更

- 除去前に `com.apple.quarantine` の有無を確認し、付いている場合だけ `xattr -d` を実行
- 保護された bundle 内部へ再帰しないよう `-dr` から `-d`（bundle ルートのみ）に変更。Gatekeeper の起動ダイアログ判定は bundle ルートの検疫フラグなので十分

## 確認

- raw / 展開後とも `sh -n` OK
- 実機で実行してエラーゼロ・承認済みアプリを正しくスキップすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)