### PR TITLE
[fix] zsh compinit の insecure files 中断を防ぐ

### DIFF
--- a/chezmoi/dot_config/zsh/dot_zshrc
+++ b/chezmoi/dot_config/zsh/dot_zshrc
@@ -19,7 +19,11 @@ elif command -v brew >/dev/null 2>&1; then
 fi
 
 autoload -Uz compinit
-compinit
+# -i: 不安全な補完ファイルがあっても中断・プロンプトせず無視して続行する。
+# 例: Docker などの cask が置く補完ファイル(_docker 等)はアプリ同梱ファイルへの
+# symlink で、リンク先が別UID所有のため compaudit が insecure と判定する。
+# 権限ではなく所有者の問題で chmod では直せないため、-i で無視する運用とする。
+compinit -i
 
 if command -v sheldon >/dev/null 2>&1; then
   eval "$(sheldon source)"


### PR DESCRIPTION
## 概要

新規セットアップ時に `zsh compinit: insecure files` の対話プロンプトが出て、補完初期化が中断される問題を修正する。

## 原因

Docker などの cask が `~/.../site-functions` に置く補完ファイル（`_docker` 等）は、アプリ同梱ファイルへの symlink になっている。そのリンク先が別 UID（例: `503`/`staff`）所有のため、`compaudit` が insecure と判定する。書き込み権限ではなく**所有者**の問題であり、`chmod` では直せない（`sudo chown` が必要でアプリ更新のたびに戻る）。

## 変更

- `chezmoi/dot_config/zsh/dot_zshrc`: `compinit` → `compinit -i`（不安全ファイルがあっても中断・プロンプトせず無視して続行）

## 確認

- `zsh -n` OK
- 対象マシン（別 UID 所有の Docker 補完 symlink あり）で `compinit -i` が中断せず完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)