### PR TITLE
[revert] compinit を strict に戻す

### DIFF
--- a/chezmoi/dot_config/zsh/dot_zshrc
+++ b/chezmoi/dot_config/zsh/dot_zshrc
@@ -19,11 +19,7 @@ elif command -v brew >/dev/null 2>&1; then
 fi
 
 autoload -Uz compinit
-# -i: 不安全な補完ファイルがあっても中断・プロンプトせず無視して続行する。
-# 例: Docker などの cask が置く補完ファイル(_docker 等)はアプリ同梱ファイルへの
-# symlink で、リンク先が別UID所有のため compaudit が insecure と判定する。
-# 権限ではなく所有者の問題で chmod では直せないため、-i で無視する運用とする。
-compinit -i
+compinit
 
 if command -v sheldon >/dev/null 2>&1; then
   eval "$(sheldon source)"


### PR DESCRIPTION
## 概要

`compinit -i` を素の `compinit`(strict)に戻す。

## 背景

`compinit -i`（PR #20）を入れた契機の `insecure files` は、dotfiles 管理外で未使用の docker cask が `site-functions` に置く別 UID（503/staff）所有の補完 symlink（`_docker` 等）が原因だった。当該 docker を削除して `compaudit` がクリーンになり、素の `compinit` が通ることを確認済み。

`-i` は不安全ファイルを黙って無視して続行するため、将来また insecure な補完が現れても気づけない。根本原因が解消した今、strict に戻す。

## 確認

- `zsh -n` OK
- 対象マシンで docker 削除後、`compaudit` 出力なし・`compinit`（-i なし）exit 0 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)