### PR TITLE
[fix] wezterm のフォントを実在の Monaspace Neon NF に合わせる

### DIFF
--- a/chezmoi/dot_config/wezterm/wezterm.lua
+++ b/chezmoi/dot_config/wezterm/wezterm.lua
@@ -3,9 +3,8 @@ local wezterm = require("wezterm")
 local config = wezterm.config_builder()
 
 config.font = wezterm.font_with_fallback({
-  "Hack Nerd Font Mono",
-  "Hack Nerd Font",
-  "Hack",
+  "Monaspace Neon NF",
+  "Monaspace Neon",
 })
 config.harfbuzz_features = { "dlig=0" }
 config.font_size = 20.0


### PR DESCRIPTION
## 概要

WezTerm 起動時の `Unable to load a font ... 'Hack Nerd Font Mono'` を解消する。

## 原因

`wezterm.lua` だけ `Hack Nerd Font` を指定したまま取り残されていた。Brewfile が導入するのは `font-monaspace-nf`（`Monaspace Neon NF`）で、Hack はどの環境にも入らずフォールバックしていた。sketchybar / ghostty など他設定はすでに Monaspace 系に統一済み。

## 変更

- `chezmoi/dot_config/wezterm/wezterm.lua` のフォントを `Hack Nerd Font Mono` → `Monaspace Neon NF`（フォールバックに `Monaspace Neon`）

## 確認

- `luac -p` 構文 OK
- 対象マシンに `Monaspace Neon NF` が実在（`~/Library/Fonts` に `.otf`、system_profiler も認識）することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)