### PR TITLE
[feat] yashiki をログイン自動起動し、起動後に sketchybar を reload する

### DIFF
--- a/chezmoi/dot_config/yashiki/executable_init
+++ b/chezmoi/dot_config/yashiki/executable_init
@@ -138,3 +138,14 @@ yashiki rule-add --app-name borders ignore
 yashiki rule-add --app-name sketchybar ignore
 yashiki rule-add --app-id com.raycast.macos ignore
 yashiki rule-add --app-id com.knollsoft.Hookshot ignore
+
+##### sketchybar 再初期化 #####
+# yashiki 起動が完了したこの時点で sketchybar を reload する。
+# sketchybar の bridge (yashiki_bridge.sh) と list-outputs は起動時に
+# yashiki が動いている前提で、起動順の競合で sketchybar が先に上がると
+# workspace 表示が壊れる。ここで reload し live な yashiki へ繋ぎ直す。
+# sketchybar 未起動時は brew services が後から起動し、その時点で yashiki は
+# 既に上がっているため問題ない（reload 失敗は無視）。
+if [ -x /opt/homebrew/bin/sketchybar ]; then
+  /opt/homebrew/bin/sketchybar --reload >/dev/null 2>&1 || true
+fi

--- a/chezmoi/run_onchange_30_configure-login-items.sh.tmpl
+++ b/chezmoi/run_onchange_30_configure-login-items.sh.tmpl
@@ -7,12 +7,15 @@ tell application "System Events"
     make new login item at end with properties {name:"Raycast", path:"/Applications/Raycast.app", hidden:false}
   end if
 
-  -- Yashiki の自動起動は手動で管理する（System Settings の Open at Login に
-  -- 各自で追加）。dotfiles では作成も削除もしない。
+  -- Yashiki(タイル型WM)をログイン時に自動起動する。起動すると ~/.config/yashiki/init
+  -- が走り、最後に sketchybar を reload して bridge を繋ぎ直す。
+  if not (exists login item "Yashiki") then
+    make new login item at end with properties {name:"Yashiki", path:"/Applications/Yashiki.app", hidden:false}
+  end if
 end tell
 APPLESCRIPT
 
-# Yashiki の自動起動は廃止。過去に作成した LaunchAgent が残っていれば除去する（冪等）。
+# 旧 LaunchAgent 方式の自動起動は使わない（ログイン項目で管理）。残っていれば除去する（冪等）。
 yashiki_plist="$HOME/Library/LaunchAgents/com.shsw228.yashiki-autostart.plist"
 if [ -f "$yashiki_plist" ]; then
   launchctl bootout "gui/$(id -u)/com.shsw228.yashiki-autostart" 2>/dev/null || true


### PR DESCRIPTION
## 概要

再起動後に発生する2つの手動作業を解消する:
1. yashiki を手動で起動しないといけない
2. その後 sketchybar を手動再起動しないと workspace 表示がまともに動かない

## 原因

- yashiki の自動起動は過去に廃止され、`run_onchange_30` でも手動管理としていた
- sketchybar の bridge (`plugins/yashiki_bridge.sh`) と `items/yashiki.lua` の `list-outputs` は、sketchybar ロード時点で yashiki が稼働している前提。sketchybar は brew services で起動時に上がるため、yashiki より先に起動すると workspace 表示が壊れ、手動再起動が必要だった

## 変更

- `run_onchange_30`: `Yashiki.app` をログイン項目に追加（Raycast と同方式）
- `dot_config/yashiki/executable_init` 末尾で `sketchybar --reload` を実行。yashiki 起動完了時に sketchybar を再初期化し、bridge / list-outputs を live な yashiki に繋ぎ直す。起動順が前後しても収束する

## 確認

- `sh -n` / `chezmoi execute-template` OK
- bridge 起動箇所 `items/init.lua:64`、`list-outputs` 依存 `items/yashiki.lua` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)