### PR TITLE
[chore] Claude Code の settings.json を現行の実体に合わせる

### DIFF
--- a/chezmoi/dot_claude/settings.json
+++ b/chezmoi/dot_claude/settings.json
@@ -21,7 +21,12 @@
       }
     }
   },
+  "language": "Japanese",
   "effortLevel": "high",
-  "skipAutoPermissionPrompt": true,
-  "tui": "fullscreen"
+  "tui": "fullscreen",
+  "theme": "dark-ansi",
+  "editorMode": "normal",
+  "verbose": true,
+  "preferredNotifChannel": "ghostty",
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## 概要

リポジトリの `dot_claude/settings.json` が古く、Claude Code が実行時に追記する `language` / `theme` / `editorMode` / `verbose` / `preferredNotifChannel` を欠いていた。このため `chezmoi apply` のたびにこれらのキーが実体から消える往復ドリフトが発生していた。

## 変更

- 現行の実体（`~/.claude/settings.json`）を正として `chezmoi re-add` でソースへ取り込み

## 確認

- `chezmoi status` で `.claude/settings.json` のドリフトが解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)